### PR TITLE
0.2.6

### DIFF
--- a/databricks_test.py
+++ b/databricks_test.py
@@ -4,13 +4,11 @@ import logging
 from policyweaver.weaver import WeaverAgent
 from policyweaver.plugins.databricks.model import DatabricksSourceMap
 
-#Load config from the default path (./settings.yaml)
-#config = DatabricksSourceMap.from_yaml("./config.yaml")
+#Load config
 config = DatabricksSourceMap.from_yaml("./settings.yaml")
 
-#configure logging for the client
-log_level = logging.INFO
-
+#configure logging for the client (DEBUG for verbose output)
+log_level = logging.DEBUG
 logger = logging.getLogger("POLICY_WEAVER")
 logger.setLevel(log_level)
 

--- a/policyweaver/models/common.py
+++ b/policyweaver/models/common.py
@@ -21,6 +21,12 @@ class CommonBaseModel(BaseModel):
 
     @property
     def hash_sha256(self):
+        """
+        Computes the SHA-256 hash of the model's JSON representation.
+        This is useful for generating a unique identifier for the model based on its content.
+        Returns:
+            str: The SHA-256 hash of the model's JSON representation.
+        """
         data = json.dumps(self.model_dump_json(exclude_none=True, exclude_unset=True), sort_keys=True)
         return hashlib.sha256(data.encode('utf-8')).hexdigest()
     

--- a/policyweaver/models/config.py
+++ b/policyweaver/models/config.py
@@ -51,12 +51,17 @@ class FabricConfig(CommonBaseModel):
         workspace_name (str): The name of the Azure workspace.
         mirror_id (str): The ID of the mirror in the fabric.
         mirror_name (str): The name of the mirror in the fabric.
+        fabric_role_suffix (str): The suffix for the fabric role, default is "PWPolicy".
+        delete_default_reader_role (bool): Flag to indicate whether to delete the default reader role,
+            default is False.
     """
     tenant_id: Optional[str] = Field(alias="tenant_id", default=None)
     workspace_id: Optional[str] = Field(alias="workspace_id", default=None)
     workspace_name: Optional[str] = Field(alias="workspace_name", default=None)
     mirror_id: Optional[str] = Field(alias="mirror_id", default=None)
     mirror_name: Optional[str] = Field(alias="mirror_name", default=None)
+    fabric_role_suffix: Optional[str] = Field(alias="fabric_role_suffix", default="PWPolicy")
+    delete_default_reader_role: Optional[bool] = Field(alias="delete_default_reader_role", default=False)
 
 class ServicePrincipalConfig(CommonBaseModel):
     """

--- a/policyweaver/plugins/databricks/api.py
+++ b/policyweaver/plugins/databricks/api.py
@@ -203,6 +203,7 @@ class DatabricksAPIClient:
             self.logger.debug(f"DBX WORKSPACE Policy Map for {api_catalog.name}: {json.dumps(self.__workspace, default=pydantic_encoder, indent=4)}")
             return (self.__account, self.__workspace)
         except NotFound:
+            self.logger.error(f"DBX WORKSPACE Catalog {source.name} not found in workspace {source.url}.")
             return None
 
     def __get_workspace_users__(self) -> List[DatabricksUser]:

--- a/policyweaver/weaver.py
+++ b/policyweaver/weaver.py
@@ -45,8 +45,22 @@ class WeaverAgent:
         weaver = Weaver(config)
         await weaver.apply(policy_export)
     """
-    fabric_policy_role_prefix = "xxPOLICYWEAVERxx"
+    __FABRIC_POLICY_ROLE_SUFFIX = "PolicyWeaver"
+    __FABRIC_DEFAULT_READER_ROLE = "DefaultReader"
 
+    @property
+    def FabricPolicyRoleSuffix(self) -> str:
+        """
+        Get the Fabric policy role suffix from the configuration.
+        If the suffix is not set in the configuration, it defaults to "PolicyWeaver".
+        Returns:
+            str: The Fabric policy role suffix.
+        """
+        if self.config and self.config.fabric and self.config.fabric.fabric_role_suffix:
+            return self.config.fabric.fabric_role_suffix
+        else:
+            return self.__FABRIC_POLICY_ROLE_SUFFIX
+    
     @staticmethod
     async def run(config: SourceMap, source_snapshot_hndlr:callable = None, 
                   fabric_snaphot_hndlr:callable = None, unmapped_policy_hndlr:callable = None) -> None:
@@ -168,11 +182,11 @@ class WeaverAgent:
         # Append policies not managed by PolicyWeaver
         if self.current_fabric_policies:
             for p in self.current_fabric_policies:
-                if not p.name.startswith(self.fabric_policy_role_prefix):
+                if not self.FabricPolicyRoleSuffix in p.name:
                     continue
 
                 # Check if the policy already exists
-                existing_policy = next((ap for ap in access_policies if ap.name == p.name), None)
+                existing_policy = next((ap for ap in access_policies if ap.name.lower() == p.name.lower()), None)
 
                 if existing_policy:
                     # Update existing policy
@@ -185,10 +199,16 @@ class WeaverAgent:
                     access_policies.append(p)
                     inserted_policies += 1                   
 
-            xapply = [p for p in self.current_fabric_policies if not p.name.startswith(self.fabric_policy_role_prefix)]
+            xapply = [p for p in self.current_fabric_policies if not p.name.lower().endswith(self.FabricPolicyRoleSuffix.lower())]
 
             if xapply:
                 self.logger.debug(f"Unmanaged Policies: {len(xapply)}")
+
+                if self.config.fabric.delete_default_reader_role:
+                    self.logger.debug("Deleting default reader role as configured...")
+                    for p in xapply:
+                        xapply = [p for p in xapply if not p.name.lower() == self.__FABRIC_DEFAULT_READER_ROLE.lower()]
+
                 unmanaged_policies += len(xapply)
                 access_policies.extend(xapply)
             
@@ -306,11 +326,13 @@ class WeaverAgent:
             str: The generated role name in the format "xxPOLICYWEAVERxx<CATALOG><SCHEMA><TABLE>".
         """
         if policy.catalog_schema:
-            role_description = f"{policy.catalog_schema.upper()}x{'' if not policy.table else policy.table.upper()}"
+            role_description = f"{policy.catalog_schema.replace(' ', '')} {'' if not policy.table else policy.table.replace(' ', '')}"
         else:
-            role_description = policy.catalog.upper()
+            role_description = policy.catalog.replace(" ", "")
 
-        return re.sub(r'[^a-zA-Z0-9]', '', f"{self.fabric_policy_role_prefix}{role_description}")
+        role_name = f"{role_description.title()}{self.FabricPolicyRoleSuffix}".replace(" ", "")
+
+        return re.sub(r'[^a-zA-Z0-9]', '', role_name)
     
     def __build_data_access_policy__(self, policy:PolicyExport, permission:PermissionType, access_policy_type:FabricPolicyAccessType) -> DataAccessPolicy:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "policy-weaver"
-version = "0.2.5"
+version = "0.2.6"
 description = "Policy Weaver for Microsoft Fabric"
 readme = "README.md"
 requires-python = ">=3.11.8"


### PR DESCRIPTION
- Updated Fabric role name strategy
- Added config for custom role prefix...role prefix is required
- Added flag to allow Policy Weaver to delete the DefaultReader role when configured. Defaults to False.