### PR TITLE
Key vault secrets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 keyvault:
   use_key_vault: <true if you use a key vault and secret names, false if you provide the secrets>
   name: <nameofkeyvault>
-  authentication_method: <authentication method: currently possible: azure_cli>
+  authentication_method: <authentication method: currently possible: azure_cli or fabric_notebook>
 fabric:
   mirror_id: <your fabric mirrored item id>
   mirror_name: <your fabric mirrored item name>

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,7 @@
+keyvault:
+  use_key_vault: <true if you use a key vault and secret names, false if you provide the secrets>
+  name: <nameofkeyvault>
+  authentication_method: <authentication method: currently possible: azure_cli>
 fabric:
   mirror_id: <your fabric mirrored item id>
   mirror_name: <your fabric mirrored item name>
@@ -6,13 +10,13 @@ fabric:
   fabric_role_suffix: PWPolicy
   delete_default_reader_role: true
 service_principal:
-  client_id: <your azure SP client id>
-  client_secret: <your azure SP secret>
-  tenant_id: <your azure tenant id again>
+  client_id: <Depending on the keyvault setting: the keyvault secret name or your azure SP client id>
+  client_secret: <Depending on the keyvault setting: the keyvault secret name or your azure SP secret>
+  tenant_id: <Depending on the keyvault setting: the keyvault secret name or your azure tenant id again>
 source:
   name: <your databricks catalog name as named in Azure Databricks>
 type: UNITY_CATALOG
 databricks:
   workspace_url: https://adb-xxxxxxxxxxx.azuredatabricks.net/
   account_id: <your databricks account id>
-  account_api_token: <your databricks secret> 
+  account_api_token: <Depending on the keyvault setting: the keyvault secret name or your databricks secret> 

--- a/getting_started/0_prerequisites.md
+++ b/getting_started/0_prerequisites.md
@@ -31,22 +31,26 @@ You can use VS Code or any other tool to create a yaml file with the following c
 
 
 ```yml
+keyvault:
+  use_key_vault: <true if you use a key vault and secret names, false if you provide the secrets>
+  name: <nameofkeyvault>
+  authentication_method: <authentication method: currently possible: azure_cli or fabric_notebook>
 fabric:
-  mirror_id: <your fabric mirrored item id>
-  mirror_name: <your fabric mirrored item name>
-  workspace_id: <your fabric workspace id>
-  tenant_id: <your fabric tenant id>
+  mirror_id: <your fabric mirrored item id>
+  mirror_name: <your fabric mirrored item name>
+  workspace_id: <your fabric workspace id>
+  tenant_id: <your fabric tenant id>
   fabric_role_suffix: PWPolicy
   delete_default_reader_role: true
 service_principal:
-  client_id: <your azure SP client id>
-  client_secret: <your azure SP secret>
-  tenant_id: <your azure tenant id again>
+  client_id: <Depending on the keyvault setting: the keyvault secret name or your azure SP client id>
+  client_secret: <Depending on the keyvault setting: the keyvault secret name or your azure SP secret>
+  tenant_id: <Depending on the keyvault setting: the keyvault secret name or your azure tenant id again>
 source:
-  name: <your databricks catalog name as named in Azure Databricks>
+  name: <your databricks catalog name as named in Azure Databricks>
 type: UNITY_CATALOG
 databricks:
-  workspace_url: https://adb-xxxxxxxxxxx.azuredatabricks.net/
-  account_id: <your databricks account id>
-  account_api_token: <your databricks secret> 
+  workspace_url: https://adb-xxxxxxxxxxx.azuredatabricks.net/
+  account_id: <your databricks account id>
+  account_api_token: <Depending on the keyvault setting: the keyvault secret name or your databricks secret>
 ```

--- a/policyweaver/core/conf.py
+++ b/policyweaver/core/conf.py
@@ -1,7 +1,9 @@
 import os
 from uuid import uuid4
+import requests
 
 from policyweaver.models.config import SourceMap
+from policyweaver.core.auth import AzureCLIClient
 
 class Configuration:
     """
@@ -25,4 +27,53 @@ class Configuration:
         if not config.correlation_id:
             config.correlation_id = str(uuid4())
 
+        if config.keyvault and config.keyvault.use_key_vault:
+            Configuration.retrieve_key_vault_credentials(config)
+
         os.environ['CORRELATION_ID'] = config.correlation_id
+
+    @staticmethod
+    def retrieve_key_vault_credentials(config:SourceMap):
+        """
+        Retrieve the Key Vault credentials from the configuration.
+        This method checks if the Key Vault is enabled and retrieves the necessary credentials.
+        Args:
+            config (SourceMap): The SourceMap instance containing configuration values.
+        Returns:
+            dict: A dictionary containing Key Vault credentials if available.
+        """
+        if not(config.keyvault and config.keyvault.use_key_vault):
+            raise ValueError("Key Vault is not enabled in the configuration.")
+        if not(config.keyvault.name and config.keyvault.authentication_method):
+            raise ValueError("Key Vault name and authentication method must be provided.")
+        
+        if config.keyvault.authentication_method == "azure_cli":
+            key_vault_name = config.keyvault.name
+            credential = AzureCLIClient()
+            credential.initialize()
+            
+            def get_secret(secret_name):
+                """
+                Retrieve a secret from Azure Key Vault using the Azure CLI credentials.
+                Args:
+                    secret_name (str): The name of the secret to retrieve.
+                Returns:
+                    str: The value of the secret.
+                """
+                key_vault_base_url = f"https://{key_vault_name}.vault.azure.net"
+                headers = credential.get_token_header(key_vault_base_url)
+                
+                keyvault_url = f"{key_vault_base_url}/secrets/{secret_name}?api-version=7.4"
+                response = requests.get(keyvault_url, headers=headers)
+                
+                if response.status_code == 200:
+                    return response.json()["value"]
+                else:
+                    raise Exception(f"Failed to retrieve secret {secret_name}: {response.status_code} - {response.text}")
+                
+        
+        config.service_principal.tenant_id = get_secret(config.service_principal.tenant_id)
+        config.service_principal.client_id = get_secret(config.service_principal.client_id)
+        config.service_principal.client_secret = get_secret(config.service_principal.client_secret)
+        if config.databricks:
+            config.databricks.account_api_token = get_secret(config.databricks.account_api_token)

--- a/policyweaver/core/conf.py
+++ b/policyweaver/core/conf.py
@@ -5,6 +5,10 @@ import requests
 
 from policyweaver.models.config import SourceMap
 from policyweaver.core.auth import AzureCLIClient
+try:
+    import notebookutils
+except:
+    pass
 
 class Configuration:
     """

--- a/policyweaver/models/config.py
+++ b/policyweaver/models/config.py
@@ -75,6 +75,19 @@ class ServicePrincipalConfig(CommonBaseModel):
     client_id: Optional[str] = Field(alias="client_id", default=None)
     client_secret: Optional[str] = Field(alias="client_secret", default=None)
 
+class KeyVaultConfig(CommonBaseModel):
+    """
+    Configuration for Azure Key Vault.
+    Attributes:
+        use_key_vault (bool): Flag to indicate whether to use Azure Key Vault.
+        name (str): The name of the Key Vault.
+        authentication_method (str): The authentication method to use for accessing the Key Vault.
+    """
+    use_key_vault: Optional[bool] = Field(alias="use_key_vault", default=False)
+    name: Optional[str] = Field(alias="name", default=None)
+    authentication_method: Optional[str] = Field(alias="authentication_method", default=None)
+
+
 class CatalogItem(CommonBaseModel):
     """
     Base model for catalog items.
@@ -126,6 +139,7 @@ class SourceMap(CommonBaseModel):
     fabric: Optional[FabricConfig] = Field(alias="fabric", default=None)
     service_principal: Optional[ServicePrincipalConfig] = Field(alias="service_principal", default=None)
     mapped_items: Optional[List[SourceMapItem]] = Field(alias="mapped_items", default=None)
+    keyvault: Optional[KeyVaultConfig] = Field(alias="keyvault", default=None)
 
     _default_paths = ['./settings.yaml']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.11.8"
 authors = [
      {name = "Tonio Lora", email = "tonio.lora@microsoft.com"},
      {name = "Christopher Price", email = "chriprice@microsoft.com"},
-     {name = "Emily Nguyen", email="Emily.Nguyen@microsoft.com"}
+     {name = "Emily Nguyen", email="Emily.Nguyen@microsoft.com"},
+     {name = "Andreas J Rederer", email = "andreas.rederer@microsoft.com"}
 ]
 dependencies = [
     "azure-identity>=1.19.0",


### PR DESCRIPTION
This PR will add the possibility to hide your secrets in a Azure Key vault.
It uses the logged-in user either from the fabric notebook context or via Azure CLI to connect to the keyvault.

The values in the config.yaml will change in that case, that you configure the key vault connection and give the names of the secrets instead of the real values